### PR TITLE
feat: add Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /target
 **/*.rs.bk
 Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea/
 /target
 **/*.rs.bk
 Cargo.lock

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 A simple global allocator for Rust which hooks into `libc`.
 Useful when linking `no_std` + `alloc` code into existing embedded C code.
 
-Uses `posix_memalign` for allocations, `realloc` for reallocations, and `free` for deallocations.
+On Unix-like OSs, use `posix_memalign` for allocations, `realloc` for reallocations, and `free` for deallocations.
+
+On Windows, use native [`_aligned_malloc`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc) for allocations, [`_aligned_realloc`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-realloc) for reallocations, and [`_aligned_free`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-free) for deallocations.
 
 ## Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,13 @@ use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::c_void;
 use core::ptr;
 
-mod libc;
-
 /// Global Allocator which hooks into libc to allocate / free memory.
 pub struct LibcAlloc;
 
+#[cfg(target_family = "unix")]
+mod libc;
+
+#[cfg(target_family = "unix")]
 unsafe impl GlobalAlloc for LibcAlloc {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -42,7 +44,7 @@ unsafe impl GlobalAlloc for LibcAlloc {
 
     #[inline]
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        // Unfortuantely, calloc doesn't make any alignment guarantees, so the memory
+        // Unfortunately, calloc doesn't make any alignment guarantees, so the memory
         // has to be manually zeroed-out.
         let ptr = self.alloc(layout);
         if !ptr.is_null() {
@@ -59,5 +61,35 @@ unsafe impl GlobalAlloc for LibcAlloc {
     #[inline]
     unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
         libc::realloc(ptr as *mut c_void, new_size) as *mut u8
+    }
+}
+
+#[cfg(target_family = "windows")]
+mod win_crt;
+
+#[cfg(target_family = "windows")]
+unsafe impl GlobalAlloc for LibcAlloc {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        return win_crt::_aligned_malloc(layout.size(), layout.align()) as *mut u8;
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        return win_crt::_aligned_free(ptr as *mut c_void);
+    }
+
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = self.alloc(layout);
+        if !ptr.is_null() {
+            ptr::write_bytes(ptr, 0, layout.size());
+        }
+        return ptr;
+    }
+
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        return win_crt::_aligned_realloc(ptr as *mut c_void, new_size, layout.align()) as *mut u8;
     }
 }

--- a/src/win_crt.rs
+++ b/src/win_crt.rs
@@ -1,0 +1,14 @@
+#![allow(non_camel_case_types)]
+
+use core::ffi::c_void;
+
+/// unsigned __int64 or unsigned integer, depending on the target platform
+///
+/// see: https://docs.microsoft.com/en-us/cpp/c-runtime-library/standard-types
+pub type size_t = usize;
+
+extern "C" {
+    pub fn _aligned_malloc(size: size_t, align: size_t) -> *mut c_void;
+    pub fn _aligned_realloc(p: *mut c_void, size: size_t, align: size_t) -> *mut c_void;
+    pub fn _aligned_free(p: *mut c_void);
+}


### PR DESCRIPTION
issue: #1 

On Windows, use CRT `_aligned_xx` functions to allocate, reallocate and deallocate.