### PR TITLE
Add `global` feature that defines `#[global_allocator]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["malloc", "memalign", "libc", "allocator", "no_std"]
 categories = ["development-tools::ffi", "embedded", "no-std"]
 
 [features]
-# settings this feature will define the `#[global_allocator]`
+# enabling this feature will define the `#[global_allocator]`
 global = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ repository  = "https://github.com/daniel5151/libc_alloc"
 keywords = ["malloc", "memalign", "libc", "allocator", "no_std"]
 categories = ["development-tools::ffi", "embedded", "no-std"]
 
-[dependencies]
+[features]
+global = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ keywords = ["malloc", "memalign", "libc", "allocator", "no_std"]
 categories = ["development-tools::ffi", "embedded", "no-std"]
 
 [features]
+# settings this feature will define the `#[global_allocator]`
 global = []

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ use libc_alloc::LibcAlloc;
 static ALLOCATOR: LibcAlloc = LibcAlloc;
 ```
 
+Alternatively, with the `global` Cargo feature, the crate only needs to be pulled in:
+
+```rust
+extern crate libc_alloc;
+```
+
 ## Project Status
 
 Given how dead-simple this crate is, I doubt it will need to be updated very often.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,10 @@ mod win_crt;
 /// Global Allocator which hooks into libc to allocate / free memory.
 pub struct LibcAlloc;
 
+#[cfg(feature = "global")]
+#[global_allocator]
+static ALLOCATOR: LibcAlloc = LibcAlloc;
+
 #[cfg(not(target_family = "windows"))]
 unsafe impl GlobalAlloc for LibcAlloc {
     #[inline]


### PR DESCRIPTION
With the feature it suffices to include the crate in a project, the user doesn't have to hook up the global allocator themselves. This pattern is used by panic handler crates [as well](https://github.com/korken89/panic-halt/blob/master/src/lib.rs#L30).