### PR TITLE
Implement posix_memalign()-based MacOS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Useful when linking `no_std` + `alloc` code into existing C codebases.
 
 On Unix-like OSs, use `memalign` for allocations, and `free` for deallocations.
 
+On macOS, use `posix_memalign` for allocations, and `free` for deallocations.
+
 On Windows, use native [`_aligned_malloc`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc) for allocations, [`_aligned_realloc`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-realloc) for reallocations, and [`_aligned_free`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-free) for deallocations.
 
 ## Example

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -10,5 +10,10 @@ pub type size_t = usize;
 
 extern "C" {
     pub fn free(p: *mut c_void);
+
+    #[cfg(not(target_os = "macos"))]
     pub fn memalign(align: size_t, size: size_t) -> *mut c_void;
+
+    #[cfg(target_os = "macos")]
+    pub fn posix_memalign(ptr: *mut *mut c_void, align: size_t, size: size_t) -> core::ffi::c_int;
 }


### PR DESCRIPTION
This PR introduces support for MacOS by utilizing posix_memalign() in place of memalign() for memory allocation. The change is targeted specifically at MacOS environments, as indicated by conditional compilation. The main changes include:

1. **Memory Allocation Adjustment**: Modified the allocator function to use posix_memalign() for MacOS. This addresses compatibility issues with the MacOS environment where memalign() is not available.
2. **Double Casting Clarification**: Included a tricky double cast necessary for the posix_memalign() function. This part of the code is thoroughly commented for clarity and understanding.
3. **Updated Documentation**: Revised the README.md to reflect the new changes and their implications for MacOS users.
4. **Version Bump**: Incremented the version number to signify the addition of a new feature and compatibility enhancement.

This implementation differs from another fork's approach, particularly regarding the handling of errno. After reviewing that fork, I opted for a more straightforward implementation. This fork has been tested and work on my MacOS machine.